### PR TITLE
processNonHistogramLikeMetircs: ignore unsupported types

### DIFF
--- a/receiver.go
+++ b/receiver.go
@@ -865,7 +865,13 @@ func (ca *customAppender) processNonHistogramLikeMetrics(metricName string, meta
 		}
 
 	default:
-		return fmt.Errorf("unknown recognized metric type: %s", metadataType)
+		// Due to the number of unwieldy metric types in the wild
+		// that we might not know about, it is safer for us to not return
+		// an error and let scraping continue. Log a message instead of
+		// returning a non-nil error so that processing of other metrics
+		// can go on. See Issue https://github.com/orijtech/promreceiver/issues/3
+		ca.logger.Log("error", "unknown recognized metric type", "type", metadataType)
+		return nil
 	}
 
 	node := nodeFromJobNameAddress(jobName, address, scheme)


### PR DESCRIPTION
Encountered in the wild, a user was getting Prometheus metrics from
cadvisor but unfortunately their scrape featured "summary" which
isn't yet supported in the OpenCensus API (at least to the least
of my knowledge). Due to the unwiedly number of types of metrics
out there, it is prudent to log the unsupported type but return
a nil error so that processing can go on per scrape.

The log will look something like this:

    error="unknown recognized metric type" type=summary

Fixes #3